### PR TITLE
Load explicitly specified numeric cell types

### DIFF
--- a/NanoXLSX/LowLevel/WorksheetReader.cs
+++ b/NanoXLSX/LowLevel/WorksheetReader.cs
@@ -359,7 +359,7 @@ namespace NanoXLSX.LowLevel
             {
                 return GetDateTimeValue(value, address, Cell.CellType.TIME);
             }
-            else if (type == null) // try numeric if not parsed as date or time, before numeric
+            else if (type == null || type == "n") // try numeric if not parsed as date or time, before numeric
             {
                 return GetNumericValue(value, address);
             }


### PR DESCRIPTION
Writing a file with NanoXLSX and then loading it back in incorrectly parses the number types.   That is, when writing an xlsx, NanoXLSX creates a row that looks like the following (I copied it straight out of sheet1.xml from the zip).

```
    <row r="7">
      <c t="s" r="A7">
        <v>7</v>
      </c>
      <c t="n" r="B7">
        <v>0</v>
      </c>
      <c t="n" r="C7">
        <v>0</v>
      </c>
      <c t="n" r="D7">
        <v>0</v>
      </c>
      <c t="n" r="E7">
        <v>0</v>
      </c>
      <c t="n" r="F7">
        <v>0</v>
      </c>
      <c t="n" r="G7">
        <v>0</v>
      </c>
      <c t="n" r="H7">
        <v>0</v>
      </c>
    </row>
```

Notice the t="n" on the columns (in this case, the row had all 0 numbers with a string header).  When loading this back into NanoXLSX (which I was doing in my test suite to make sure my code was correctly creating the sheets), NanoXLSX parses these as strings and so converts the value 0 to the 0th string.  Note that Excel itself correctly loads it.