### PR TITLE
Apply a style to a defined cell range without passing a list of values.

### DIFF
--- a/NanoXLSX/Worksheet.cs
+++ b/NanoXLSX/Worksheet.cs
@@ -696,6 +696,17 @@ namespace NanoXLSX
         }
 
         /// <summary>
+        /// Applies a style to a defined cell range.
+        /// </summary>
+        /// <param name="cellRange"></param>
+        /// <param name="style"></param>
+        public void AddCellRange(string cellRange, Style style)
+        {
+            Range range = Cell.ResolveCellRange(cellRange);
+            AddCellRangeInternal(range.StartAddress, range.EndAddress, style);
+        }
+
+        /// <summary>
         /// Internal function to add a generic list of value to the defined cell range
         /// </summary>
         /// <typeparam name="T">Data type of the generic value list</typeparam>
@@ -722,6 +733,35 @@ namespace NanoXLSX
                 list[i].ColumnNumber = addresses[i].Column;
                 list[i].WorksheetReference = this;
                 AddNextCell(list[i], false, style);
+            }
+        }
+
+        /// <summary>
+        /// Internal function to add an empty list and mantain existing values to the defined cell range.
+        /// </summary>
+        /// <param name="startAddress"></param>
+        /// <param name="endAddress"></param>
+        /// <param name="style"></param>
+        private void AddCellRangeInternal(Address startAddress, Address endAddress, Style style)
+        {
+            List<Address> addresses = Cell.GetCellRange(startAddress, endAddress) as List<Address>;
+            List<string> values = new List<string>(addresses.Count);
+            for (int i = 0; i < addresses.Count; i++) values.Add("");
+            List<Cell> list = Cell.ConvertArray(values) as List<Cell>;
+            int len = values.Count;
+            for (int i = 0; i < len; i++)
+            {
+                list[i].RowNumber = addresses[i].Row;
+                list[i].ColumnNumber = addresses[i].Column;
+                list[i].WorksheetReference = this;
+                if (cells.ContainsKey(new Address(addresses[i].Column, addresses[i].Row).ToString()))
+                {
+                    GetCell(new Address(addresses[i].Column, addresses[i].Row)).SetStyle(style);
+                }
+                else
+                {
+                    AddNextCell(list[i], false, style);
+                }
             }
         }
         #endregion


### PR DESCRIPTION
Hello
Didn't found a method to apply a cell style to a range without passing values for all the cells.
I needed to style a range of cells without the need to pass values ​​to them.
Right now, from what I've seen, styles can only be applied to new cells or ranges with predefined series of values.
If, for example, you want to apply styles to cells that for whatever reason remain empty (without value, so they actually are not created by AddCell) in a range, the final excel will have some cells with styles and others without them.

