### PR TITLE
Number format id bug

### DIFF
--- a/NanoXLSX/LowLevel/StyleReader.cs
+++ b/NanoXLSX/LowLevel/StyleReader.cs
@@ -451,7 +451,7 @@ namespace NanoXLSX.LowLevel
                         // Undefined values may occur if the file was saved by an Excel version that has implemented yet unknown format numbers (undefined in NanoXLSX) 
                         format = new NumberFormat();
                         format.Number = formatNumber;
-                        format.InternalID = StyleReaderContainer.GetNextNumberFormatId();
+                        format.InternalID = id;
                         StyleReaderContainer.AddStyleComponent(format);
                     }
                     hasId = ReaderUtils.TryParseInt(ReaderUtils.GetAttribute(childNode, "borderId"), out id);

--- a/NanoXLSX/LowLevel/StyleReaderContainer.cs
+++ b/NanoXLSX/LowLevel/StyleReaderContainer.cs
@@ -170,16 +170,7 @@ namespace NanoXLSX.LowLevel
         {
             return cellXfs.Count;
         }
-
-        /// <summary>
-        /// Gets the next internal id of a number format component
-        /// </summary>
-        /// <returns>Next id of the component type (collected in this class)</returns>
-        public int GetNextNumberFormatId()
-        {
-                return numberFormats.Count;
-        }
-
+    
         /// <summary>
         /// Gets the next internal id of a border component
         /// </summary>

--- a/NanoXlsx Test/LowLevel/StyleReaderTest.cs
+++ b/NanoXlsx Test/LowLevel/StyleReaderTest.cs
@@ -1,0 +1,137 @@
+﻿using System.IO;
+using System.Text;
+using NanoXLSX.LowLevel;
+using NanoXLSX.Styles;
+using Xunit;
+
+namespace NanoXLSX_Test.LowLevel
+{
+    [Collection(nameof(SequentialCollection))]
+    public class StyleReaderTest
+    {
+        private readonly string xml;
+
+        public StyleReaderTest()
+        {
+            xml = "<styleSheet>" +
+                  " <numFmts count=\"1\">" +
+                  "   <numFmt numFmtId=\"169\" formatCode=\"Does not matter\"/>" +
+                  " </numFmts>" +
+                  " <fonts count=\"1\">" +
+                  "   <font>" +
+                  "     <sz val=\"9\"/>" +
+                  "     <color rgb=\"FF000000\"/>" +
+                  "     <name val=\"Arial\"/>" +
+                  "     <family val=\"2\"/>" +
+                  "     <charset val=\"238\"/>" +
+                  "   </font>" +
+                  " </fonts>" +
+                  " <fills count=\"1\">" +
+                  "   <fill>" +
+                  "     <patternFill patternType=\"none\"/>" +
+                  "   </fill>" +
+                  " </fills>" +
+                  " <borders count=\"1\">" +
+                  "   <border>" +
+                  "     <left/>" +
+                  "     <right/>" +
+                  "     <top/>" +
+                  "     <bottom/>" +
+                  "     <diagonal/>" +
+                  "   </border>" +
+                  " </borders>" +
+                  " <cellXfs count=\"15\">" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"20\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  "   <xf numFmtId=\"14\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>" +
+                  " </cellXfs>" +
+                  "</styleSheet>";
+        }
+
+        [Theory(DisplayName = "Test of dynamically created number formats from styles containing numFmtId")]
+        [InlineData(0)]
+        [InlineData(14)]
+        [InlineData(20)]
+        public void CreatedImplicitNumberFormatExistsWithCorrectId(int formatId)
+        {
+            using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                StyleReader styleReader = new StyleReader();
+                styleReader.Read(memStream);
+
+                NumberFormat numberFormat = styleReader.StyleReaderContainer.GetNumberFormat(formatId);
+                Assert.NotSame(null, numberFormat);
+            }
+        }
+
+        [Theory(DisplayName = "Test of dynamically created number formats from styles containing numFmtId")]
+		[InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(11)]
+        [InlineData(12)]
+        [InlineData(13)]
+		public void NumberFormatNotInSourceAreNotPresent(int formatId)
+        {
+            using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                StyleReader styleReader = new StyleReader();
+                styleReader.Read(memStream);
+
+                NumberFormat numberFormat = styleReader.StyleReaderContainer.GetNumberFormat(formatId);
+                Assert.Same(null, numberFormat);
+            }
+        }
+
+		[Fact(DisplayName = "Test of reusing dynamically created number formats from styles containing numFmtId")]
+        public void ImplicitNumberFormatBeingReUsed()
+        {
+            using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                StyleReader styleReader = new StyleReader();
+                styleReader.Read(memStream);
+
+                Style zeroStyle = styleReader.StyleReaderContainer.GetStyle(0, out _, out _);
+                Style firstStyle = styleReader.StyleReaderContainer.GetStyle(1, out _, out _);
+
+                Assert.Same(zeroStyle.CurrentNumberFormat, firstStyle.CurrentNumberFormat);
+            }
+        }
+
+
+        [Fact(DisplayName = "Test of dynamically created number formats from styles containing numFmtId")]
+        public void DateTimeImplicitNumberFormatAfter14ZeroNumberFormats()
+        {
+            using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                StyleReader styleReader = new StyleReader();
+                styleReader.Read(memStream);
+                Assert.Equal(15, styleReader.StyleReaderContainer.StyleCount);
+
+                NumberFormat.FormatNumber formatNumber = styleReader.StyleReaderContainer.GetStyle(14, out var isDateStyle, out _).CurrentNumberFormat.Number;
+
+                Assert.Equal(true, isDateStyle);
+                Assert.Equal(NumberFormat.FormatNumber.format_14, formatNumber);
+            }
+        }
+    }
+}

--- a/NanoXlsx Test/Reader/StyleReaderTest.cs
+++ b/NanoXlsx Test/Reader/StyleReaderTest.cs
@@ -4,7 +4,7 @@ using NanoXLSX.LowLevel;
 using NanoXLSX.Styles;
 using Xunit;
 
-namespace NanoXLSX_Test.LowLevel
+namespace NanoXLSX_Test.Reader
 {
     [Collection(nameof(SequentialCollection))]
     public class StyleReaderTest
@@ -77,7 +77,7 @@ namespace NanoXLSX_Test.LowLevel
         }
 
         [Theory(DisplayName = "Test of dynamically created number formats from styles containing numFmtId")]
-		[InlineData(1)]
+        [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
         [InlineData(4)]
@@ -90,7 +90,7 @@ namespace NanoXLSX_Test.LowLevel
         [InlineData(11)]
         [InlineData(12)]
         [InlineData(13)]
-		public void NumberFormatNotInSourceAreNotPresent(int formatId)
+        public void NumberFormatNotInSourceAreNotPresent(int formatId)
         {
             using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
             {
@@ -102,7 +102,7 @@ namespace NanoXLSX_Test.LowLevel
             }
         }
 
-		[Fact(DisplayName = "Test of reusing dynamically created number formats from styles containing numFmtId")]
+        [Fact(DisplayName = "Test of reusing dynamically created number formats from styles containing numFmtId")]
         public void ImplicitNumberFormatBeingReUsed()
         {
             using (MemoryStream memStream = new MemoryStream(Encoding.UTF8.GetBytes(xml)))


### PR DESCRIPTION
### Definitions
To avoid confusion (and because i dont know the oficial names) lets first define what i call "styles", "implicit number formats" and "custom number formats" in styles.xml:
Styles are xf elements inside cellXfs element inside the styleSheet.
Custom number formats are numFmt elements inside numfmts element inside styleSheet element.
Imlpicit number formats are defined by numFmtId attribute od xf element (the "style" element defined twor rows up), implicit number format ids correspond to NumberFormat.FormatNumber.

### Now for the problem:
When implicit number formats are being created when loading styles.xml from xlsx in NanoXlsX, they are getting a wrong id. Every other entity (fill, border, font...) has id equal to index, number formats do not. Number formats have special Id, non sequential. For example 0 is generic (text), 20 is timespan, 14 is date etc.. Any custom numberfromat is 164 and more. 

### Explanation:
Right now NanoXLSX assignes ids to number formats sequantially (StyleReaderContainer.GetNextNumberFormatId() which returns numberFormats.Count), so first one will get 0, second one will get 1 etc. When custom number formats are present in styles.xml, then the generated ids for implicit number formats starts at higner number (at custom number formats count). These sequential generated ids cause multiple problems:
1) When you have  at least one custom number format, and then 164 styles with attribute numFmtId = 0 (if we have more custom number formats we can have this number higher and the problem woudl still be present), then we create 164 number formats with id 1 to 164, and now we are in custom number formt ids range.
2) When you have  one custom number format, and then 13 styles with attribute numFmtId = 0 one style with numFmtId = 14, then when we are loading the style with 1 it chesk numberFormats collection for number format with id 14 and finds one, so it uses is. But the number format that was found is wrong, its for 0 (generic/text) neto for 14 (date) so our datetime is now text.
3) Even worse when we ahve the same as 2) but only 12 styles with attribute numFmtId = 0 one style with numFmtId = 20 (timespan) and one style with numFmtId = 14 (date), then our datetime style will get the existingin numberformat with id 14 which is actually the one created from 20, so our date is now timespan and if we use enforcetype in importoptions ti will be 1.1.1900

### Steps to create XlsX that will load date as timespan and when used as date in c# will produce wrong date (no extra clicking no shortcuting, no swaping steps, do exactly whats written here)
New excel (xlsx)
Set A1 text to "custom format cell" 
Set A1 format co custom a write someting thats not in implicit formats like "ss:mm"
Set A2 text to "general format with default style"
Set A3 thru A14 text to "general format with style#" where # is increasing number from 1 to 12 (texts dont matter, its just to visualise it better)
Set A3 thru A14 font colors to each different color (not default color, e need to use 12 new colros in total)
Set A15 text to "timespan" (again it does not matter what the text is)
Set A15 format exactly like this: formats => custom and select the "h:mm" (thats the one with id 20 in styles.xml) 
Set A16 text to 1.1.2024
Set A16 format to date (short) this must be the number format with id 14 in styles.xml
Save to xlsx
When loading this xlsx with NanoXlsX, cell A16 with date 1.1.2024 will be loaded as TIME and 45292.00:00:00. If we set importoptins to enforce the A column as DateTimes it will be loaded as 01.01.1900 0:00:00.
[example.xlsx](https://github.com/rabanti-github/NanoXLSX/files/14693812/example.xlsx)
