### PR TITLE
Filter could be created for just 1 cell range

### DIFF
--- a/NanoXLSX/Cell.cs
+++ b/NanoXLSX/Cell.cs
@@ -707,6 +707,10 @@ namespace NanoXLSX
             {
                 throw new FormatException("The cell range is null or empty and could not be resolved");
             }
+            if (!range.Contains(":"))
+            {
+	            return new Range(ResolveCellCoordinate(range), ResolveCellCoordinate(range));
+            }
             string[] split = range.Split(':');
             if (split.Length != 2)
             {

--- a/NanoXlsx Test/Cells/CellTest.cs
+++ b/NanoXlsx Test/Cells/CellTest.cs
@@ -511,6 +511,7 @@ namespace NanoXLSX_Test.Cells
         [InlineData("C3:C4", "C3", "C4")]
         [InlineData("$a1:Z$10", "$A1", "Z$10")]
         [InlineData("$R$9:a2", "A2", "$R$9")]
+        [InlineData("A1", "A1","A1")]
         public void ResolveCellRangeTest(string rangeString, string expectedStartAddress, string expectedEndAddress) 
         {
             NanoXLSX.Range range = Cell.ResolveCellRange(rangeString);
@@ -526,8 +527,6 @@ namespace NanoXLSX_Test.Cells
             Exception ex = Assert.Throws<NanoXLSX.Exceptions.FormatException>(() => Cell.ResolveCellRange(null));
             Assert.Equal(typeof(NanoXLSX.Exceptions.FormatException), ex.GetType());
             ex = Assert.Throws<NanoXLSX.Exceptions.FormatException>(() => Cell.ResolveCellRange(""));
-            Assert.Equal(typeof(NanoXLSX.Exceptions.FormatException), ex.GetType());
-            ex = Assert.Throws<NanoXLSX.Exceptions.FormatException>(() => Cell.ResolveCellRange("C3"));
             Assert.Equal(typeof(NanoXLSX.Exceptions.FormatException), ex.GetType());
         }
 

--- a/NanoXlsx Test/Worksheets/ColumnTest.cs
+++ b/NanoXlsx Test/Worksheets/ColumnTest.cs
@@ -202,6 +202,7 @@ namespace NanoXLSX_Test.Worksheets
         [InlineData("B1:F1", "B1:F1")]
         [InlineData("F1:B1", "B1:F1")]
         [InlineData("$B$1:$F$1", "B1:F1")]
+        [InlineData("A1","A1:A1")]
         public void SetAutoFilterTest2(string givenRange, string expectedRange)
         {
             Worksheet worksheet = new Worksheet();
@@ -227,7 +228,6 @@ namespace NanoXLSX_Test.Worksheets
         [Theory(DisplayName = "Test of the failing SetAutoFilter function on an invalid string expression")]
         [InlineData("")]
         [InlineData(null)]
-        [InlineData("A1")]
         [InlineData(":")]
         public void SetAutoFilterFailingTest2(string range)
         {

--- a/NanoXlsx Test/Worksheets/WorksheetTest.cs
+++ b/NanoXlsx Test/Worksheets/WorksheetTest.cs
@@ -1021,7 +1021,6 @@ namespace NanoXLSX_Test.Worksheets
             Worksheet worksheet = new Worksheet();
             Assert.Throws<FormatException>(() => worksheet.MergeCells(""));
             Assert.Throws<FormatException>(() => worksheet.MergeCells(null));
-            Assert.Throws<FormatException>(() => worksheet.MergeCells("A1"));
         }
 
         [Fact(DisplayName ="Test of the internal RecalculateAutoFilter function")]


### PR DESCRIPTION
#### Bug description
Function Cell.ResolveCellRange() does not accept 1 cell range, but Excel could easly generates e.g. Autofilter with just one cell.

#### Steps To Reproduce
1. Create a workbook
2. Create worksheet and fill value A1 with "text"
3. Click on Data->Filter
4. This is now unreadable xlsx file for NanoXLSX

#### Expected behavior
If i create xlsx with steps to reproduce above, function Cell.ResolveCellRange("A1") shold returns "A1:A1" range.

#### Environment (please complete the following information):
I've created unreadable xlsx in both MS Excel 2019 (Version 2402 Build 16.0.17328.20124) 32 bit  and LibreOffice Calc 7.2.4.1 (x64)
