### PR TITLE
Worksheet containing only cell with empty string will crash 

### DIFF
--- a/NanoXLSX/Worksheet.cs
+++ b/NanoXLSX/Worksheet.cs
@@ -1308,26 +1308,26 @@ namespace NanoXLSX
                     return cells.Max(x => x.Value.ColumnNumber);
                 }
             }
-            List<Cell> nonEmptyCells = cells.Values.Where(x => x.Value != null).ToList();
+            List<Cell> nonEmptyCells = cells.Values.Where(x => x.Value != null && x.Value.ToString() != string.Empty).ToList();
             if (nonEmptyCells.Count == 0)
             {
                 return -1;
             }
             if (row && min)
             {
-                return nonEmptyCells.Where(x => x.Value.ToString() != string.Empty).Min(x => x.RowNumber);
+                return nonEmptyCells.Min(x => x.RowNumber);
             }
             else if (row)
             {
-                return nonEmptyCells.Where(x => x.Value.ToString() != string.Empty).Max(x => x.RowNumber);
+                return nonEmptyCells.Max(x => x.RowNumber);
             }
             else if (min)
             {
-                return nonEmptyCells.Where(x => x.Value.ToString() != string.Empty).Min(x => x.ColumnNumber);
+                return nonEmptyCells.Min(x => x.ColumnNumber);
             }
             else
             {
-                return nonEmptyCells.Where(x => x.Value.ToString() != string.Empty).Max(x => x.ColumnNumber);
+                return nonEmptyCells.Max(x => x.ColumnNumber);
             }
         }
 

--- a/NanoXlsx Test/Worksheets/GetColumnBoundariesTest.cs
+++ b/NanoXlsx Test/Worksheets/GetColumnBoundariesTest.cs
@@ -277,6 +277,21 @@ namespace NanoXLSX_Test.Worksheets
             int maxColumn = worksheet.GetLastDataColumnNumber();
             Assert.Equal(5, minColumn);
             Assert.Equal(5, maxColumn);
-        }
-    }
+		}
+
+        [Theory(DisplayName = "Test of the GetFirstDataColumnNumber and GetLastDataColumnNumber functions with an explicitly defined, empty cell with empty string besides other column definitions")]
+		[InlineData("F5")]
+        [InlineData("A1")]
+        public void GetFirstOrLastDataColumnNumberTest3(string emptyCellAddress)
+		{
+			Worksheet worksheet = new Worksheet();
+            worksheet.AddHiddenColumn(3);
+            worksheet.AddHiddenColumn(4);
+            worksheet.AddCell(string.Empty, emptyCellAddress);
+            int minColumn = worksheet.GetFirstDataColumnNumber();
+            int maxColumn = worksheet.GetLastDataColumnNumber();
+            Assert.Equal(-1, minColumn);
+            Assert.Equal(-1, maxColumn);
+		}
+	}
 }

--- a/NanoXlsx Test/Worksheets/GetRowBoundariesTest.cs
+++ b/NanoXlsx Test/Worksheets/GetRowBoundariesTest.cs
@@ -419,7 +419,21 @@ namespace NanoXLSX_Test.Worksheets
             Assert.Equal(4, maxRow);
         }
 
+        [Theory(DisplayName = "Test of the GetFirstDataRowNumber and GetLastDataRowNumber functions with an explicitly defined, cell with empty string besides other row definitions")]
+        [InlineData("F5")]
+        [InlineData("A1")]
+        void GetFirstOrLastDataRowNumberTest3(string emptyCellAddress)
+        {
+            Worksheet worksheet = new Worksheet();
+            worksheet.AddHiddenRow(3);
+            worksheet.AddHiddenRow(4);
+            worksheet.AddCell(string.Empty, emptyCellAddress);
+            int minRow = worksheet.GetFirstDataRowNumber();
+            int maxRow = worksheet.GetLastDataRowNumber();
+            Assert.Equal(-1, minRow);
+            Assert.Equal(-1, maxRow);
+        }
 
 
-    }
+	}
 }


### PR DESCRIPTION
When we have worksheet that contains cells only filled with string.Empty (not null), then if we call any of GetFirstDataColumnNumber, GetLastDataColumnNumber, GetFirstDataRowNumber or GetLastDataRowNumber exception will be thrown. 
The problem is, when WorkSheet.GetBoundaryDataNumber filters empty cells it filters them first for not null, then check if any cells exists, and if they do then it filters on not string.Empty and calls Min/Max on the result. 
So if we have only cells containing string.Empty then they are not filtered by not null, but they are filtered by not string.Empty check and we call Min/Max on empty collection which causes exception.

Fix is to move the not string.Empty check before the if(.Any()) check, so if we have only string.Empty (or nulls) we return -1;

Two new tests that are failing before the fix.