### PR TITLE
ReadInternal() stream copies are now synchronous

### DIFF
--- a/NanoXLSX/LowLevel/XlsxReader.cs
+++ b/NanoXLSX/LowLevel/XlsxReader.cs
@@ -283,30 +283,31 @@ namespace NanoXLSX.LowLevel
         private async Task ReadInternal()
         {
             ZipArchive zf;
-            if (inputStream == null && !string.IsNullOrEmpty(filePath))
-            {
-                using (FileStream fs = new FileStream(filePath, FileMode.Open))
-                {
-                    await fs.CopyToAsync(memoryStream);
-                }
-            }
-            else if (inputStream != null)
-            {
-                using (inputStream)
-                {
-                    await inputStream.CopyToAsync(memoryStream);
-                }
-            }
-            else
-            {
-                throw new IOException("No valid stream or file path was provided to open");
-            }
-
-            memoryStream.Position = 0;
-            zf = new ZipArchive(memoryStream, ZipArchiveMode.Read);
 
             await Task.Run(() =>
             {
+                if (inputStream == null && !string.IsNullOrEmpty(filePath))
+                {
+                    using (FileStream fs = new FileStream(filePath, FileMode.Open))
+                    {
+                        fs.CopyTo(memoryStream);
+                    }
+                }
+                else if (inputStream != null)
+                {
+                    using (inputStream)
+                    {
+                      inputStream.CopyTo(memoryStream);
+                    }
+                }
+                else
+                {
+                    throw new IOException("No valid stream or file path was provided to open");
+                }
+
+                memoryStream.Position = 0;
+                zf = new ZipArchive(memoryStream, ZipArchiveMode.Read);
+
                 ReadZip(zf);
             }).ConfigureAwait(false);
         }


### PR DESCRIPTION
This change is to resolve issue #63, which I have also been experiencing: Instead of having two separate await blocks inside of ReadInternal(), the stream CopyTo functions are now called synchronously. Since the ZipArchive class and ReadZip() functions are also synchronous and rely on the memory stream data being fully available, the entire contents of ReadInternal() have been wrapped in a single await Task. This allows ReadInternal() to still behave as an async function, but for synchronous Workbook.Load() calls to still return correctly in Windows Forms applications.