### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: windows-2022
       
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/rabanti-github/NanoXLSX/security/code-scanning/1](https://github.com/rabanti-github/NanoXLSX/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. This block can be added either at the top level (applies to all jobs) or to the specific job(s) if different jobs need different permissions. Since the workflow checks out code and pushes changes, at minimum the job that commits and pushes to the repository needs `contents: write`. All other permissions should be omitted unless required. Place the `permissions` key at the `build` job level (as that is the only job), just before `runs-on`. The block should look like:  
```yaml
permissions:
  contents: write
```
This grants write access to repository contents, which is needed for the checkout and push steps.

No new imports or dependencies are necessary. The only required change is to insert the recommended block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
