### PR TITLE
Guard PluginLoader directory scan against enumeration exceptions

### DIFF
--- a/NanoXLSX.Core/Registry/PluginLoader.cs
+++ b/NanoXLSX.Core/Registry/PluginLoader.cs
@@ -76,9 +76,26 @@ namespace NanoXLSX.Registry
                 .Select(a => a.Location);
             HashSet<string> loadedPaths = new HashSet<string>(allLoadedPaths, StringComparer.InvariantCultureIgnoreCase);
 
-            List<string> referencedPaths = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.dll")
-                .Where(path => !loadedPaths.Contains(path))
-                .ToList();
+            // Guard the assembly-directory enumeration. Directory.GetFiles can throw (e.g. IOException
+            // "The parameter is incorrect" when BaseDirectory contains an entry the native enumerator
+            // cannot stat — observed when the host process's base directory is the Unity 6000.5.x editor
+            // install folder). Because this runs from WorkbookReader's static constructor, an unhandled
+            // throw here surfaces as a TypeInitializationException and permanently disables the reader
+            // for the whole AppDomain. Phase 1 above already registered plugins from loaded assemblies,
+            // so on enumeration failure we degrade to that result rather than crashing. This mirrors the
+            // per-path try/catch already used in the load loop below.
+            List<string> referencedPaths;
+            try
+            {
+                referencedPaths = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.dll")
+                    .Where(path => !loadedPaths.Contains(path))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to enumerate assemblies in {AppDomain.CurrentDomain.BaseDirectory}: {ex.Message}");
+                return;
+            }
 
             foreach (string path in referencedPaths)
             {


### PR DESCRIPTION
LoadReferencedAssemblies calls Directory.GetFiles(AppDomain.CurrentDomain.
BaseDirectory, \"*.dll\") unguarded. Because this runs from WorkbookReader's
static constructor, any throw (e.g. IOException 'The parameter is incorrect'
when BaseDirectory holds an entry the native enumerator can't stat — seen when
the host base dir is the Unity 6000.5.x editor folder) surfaces as a
TypeInitializationException and permanently disables the reader for the whole
AppDomain.

Wrap the enumeration in try/catch and fall back to the Phase 1 (loaded-assembly)
registration result, mirroring the per-path try/catch already in the load loop.